### PR TITLE
Patch essential libraries by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ nix profile install github:GuillaumeDesforges/fix-python
 
 In your Python project, create a virtual environment `.venv` and use your preferred tool (pip, poetry, ...) to install your dependencies.
 
-Then create a `.nix/libs.nix` file that returns the array of packages that you want binaries to be linked with.
-
-> Note: you may add this `.nix` folder to your project `.gitignore`.
-
+By default, `fix-python` patches the packages given in the following expression:
 ```nix
 let pkgs = import (builtins.getFlake "nixpkgs") { };
 in [
@@ -43,10 +40,14 @@ in [
 
 > Note: these three packages are fundamental for most Python packages and should never me removed.
 
+If you need to patch packages in addition to these, create a `.nix/libs.nix` file with a structure similar to the above that returns the array of packages that you want binaries to be linked with.
+
+> Note: you may add this `.nix` folder to your project `.gitignore`.
+
 Finally, call `fix-python`.
 
 ```console
-fix-python --venv .venv --libs .nix/libs.nix
+fix-python --venv .venv [--libs .nix/libs.nix]
 ```
 
 See the list of options with

--- a/fix-python
+++ b/fix-python
@@ -3,7 +3,7 @@ set -e
 
 # This script fix issues with Python binaries on NixOS
 # Usage:
-# fix-python --venv .venv [--libs libs.nix]
+# fix-python --venv .venv [--libs libs.nix] [--no-default-libs]
 
 DEFAULT_LIBS_EXPRESSION="
 (
@@ -18,9 +18,10 @@ DEFAULT_LIBS_EXPRESSION="
 
 # Help
 if [ "$1" = "--help" ]; then
-  echo "Usage: fix-python --venv .venv [--libs libs.nix]"
+  echo "Usage: fix-python --venv .venv [--libs libs.nix] [--no-default-libs]"
   echo "--venv: path to Python virtual environment"
   echo "--libs: path to a Nix file which returns a list of derivations"
+  echo "--no-default-libs: don't patch C++ standard libraries, glibc, and zlib by default"
   echo "--gpu: enable GPU support"
   echo "--verbose: increase verbosity"
   exit 0
@@ -37,6 +38,10 @@ while [ $# -gt 0 ]; do
       shift
       LIBS_PATH="$1"
       ;;
+    --no-default-libs)
+      shift
+      DEFAULT_LIBS_EXPRESSION="[]"
+      ;;
     --gpu)
       enable_gpu="1"
       ;;
@@ -45,7 +50,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: fix-python --venv .venv [--libs libs.nix]"
+      echo "Usage: fix-python --venv .venv [--libs libs.nix] [--no-default-libs]"
       exit 1
       ;;
   esac
@@ -55,7 +60,7 @@ done
 # check arguments
 if [ -z "$VENV_PATH" ]; then
   echo "Missing argument: --venv"
-  echo "Usage: fix-python --venv .venv [--libs libs.nix]"
+  echo "Usage: fix-python --venv .venv [--libs libs.nix] [--no-default-libs]"
   echo "or set VENV_PATH"
   exit 1
 fi

--- a/fix-python
+++ b/fix-python
@@ -3,11 +3,22 @@ set -e
 
 # This script fix issues with Python binaries on NixOS
 # Usage:
-# fix-python --venv .venv --libs libs.nix
+# fix-python --venv .venv [--libs libs.nix]
+
+DEFAULT_LIBS_EXPRESSION="
+(
+  let pkgs = import (builtins.getFlake \"nixpkgs\") { };
+  in [
+    pkgs.gcc.cc
+    pkgs.glibc
+    pkgs.zlib
+  ]
+)
+"
 
 # Help
 if [ "$1" = "--help" ]; then
-  echo "Usage: fix-python --venv .venv --libs libs.nix"
+  echo "Usage: fix-python --venv .venv [--libs libs.nix]"
   echo "--venv: path to Python virtual environment"
   echo "--libs: path to a Nix file which returns a list of derivations"
   echo "--gpu: enable GPU support"
@@ -34,7 +45,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       echo "Unknown argument: $1"
-      echo "Usage: fix-python --venv .venv --libs libs.nix"
+      echo "Usage: fix-python --venv .venv [--libs libs.nix]"
       exit 1
       ;;
   esac
@@ -44,14 +55,8 @@ done
 # check arguments
 if [ -z "$VENV_PATH" ]; then
   echo "Missing argument: --venv"
-  echo "Usage: fix-python --venv .venv --libs libs.nix"
+  echo "Usage: fix-python --venv .venv [--libs libs.nix]"
   echo "or set VENV_PATH"
-  exit 1
-fi
-if [ -z "$LIBS_PATH" ]; then
-  echo "Missing argument: --libs"
-  echo "Usage: fix-python --venv .venv --libs libs.nix"
-  echo "or set LIBS_PATH"
   exit 1
 fi
 
@@ -72,16 +77,27 @@ then
 fi
 
 # load libs from Nix file
-mkdir -p .nix/fix-python
-nix_libs_build_status=$(nix build --impure --expr "import $LIBS_PATH" -o .nix/fix-python/result; echo $?)
-if [ "$nix_libs_build_status" -eq "1" ]; then
-  echo "Failed to load libs from Nix file $LIBS_PATH"
-  echo ""
-  echo "Try to debug this issue with the command:"
-  echo "    nix build --impure --expr \"import $LIBS_PATH\""
-  exit 1
+if [ "$LIBS_PATH" ];
+then
+  custom_libs_expression="(import $LIBS_PATH)"
+  mkdir -p .nix/fix-python
+  nix_libs_build_status=$(
+    nix build --impure --expr "$custom_libs_expression" -o .nix/fix-python/result
+    echo $?
+  )
+  if [ "$nix_libs_build_status" -eq "1" ];
+  then
+    echo "Failed to load libs from Nix file $LIBS_PATH"
+    echo ""
+    echo "Try to debug this issue with the command:"
+    echo "    nix build --impure --expr \"import $LIBS_PATH\""
+    exit 1
+  fi
+else
+  custom_libs_expression="[]"
 fi
-nixos_python_nix_libs="$(nix eval --impure --expr "let pkgs = import (builtins.getFlake \"nixpkgs\") {}; in pkgs.lib.strings.makeLibraryPath (import $LIBS_PATH)" | sed 's/^"\(.*\)"$/\1/')"
+all_nix_libs_expression="($custom_libs_expression ++ $DEFAULT_LIBS_EXPRESSION)"
+nixos_python_nix_libs="$(nix eval --impure --expr "let pkgs = import (builtins.getFlake \"nixpkgs\") {}; in pkgs.lib.strings.makeLibraryPath $all_nix_libs_expression" | sed 's/^"\(.*\)"$/\1/')"
 if [ "$verbose" ]; then echo "nixos_python_nix_libs=$nixos_python_nix_libs"; fi
 libs="$nixos_python_nix_libs"
 


### PR DESCRIPTION
Closing #3, this patches
- `pkgs.gcc.cc`,
- `pkgs.glibc`,
- `pkgs.zlib`

by default. This behavior can be disabled with a `--no-default-libs` flag.