### PR TITLE
Update flake's derivation to use 'self' flake instead of ./. for src

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  outputs = { flake-utils, nixpkgs, ...}:
+  outputs = { self, flake-utils, nixpkgs, ...}:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -8,7 +8,7 @@
           packages.default =
             pkgs.stdenv.mkDerivation {
               name = "fix-python";
-              src = ./.;
+              src = self;
               phases = [ "unpackPhase" "installPhase" ];
               installPhase = ''
                 mkdir -p $out/bin


### PR DESCRIPTION
Small change, but determinate nix throws a warning every time this flake is built:

You can make Nix evaluate faster and copy fewer files by replacing `./.` with the `self` flake input, or `builtins.path { path = ./.; name = "source"; }`

I doubt the change matters much for such a small(and useful!) library, but the warning is quite annoying